### PR TITLE
feat: update Vault to v1.11.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Instances have SSM enable by default, no need for SSH keys.
 | <a name="input_asg"></a> [asg](#input\_asg) | n/a | `any` | n/a | yes |
 | <a name="input_asg_defaults"></a> [asg\_defaults](#input\_asg\_defaults) | n/a | `any` | <pre>{<br>  "asg_associate_public_ip_address": false,<br>  "desired_capacity": 3,<br>  "disk_size": 20,<br>  "instance_type": "t3a.micro",<br>  "key_name": null,<br>  "max_size": 3,<br>  "min_size": 0,<br>  "tags": {},<br>  "tags_as_map": {},<br>  "vpc_zone_identifier": []<br>}</pre> | no |
 | <a name="input_asg_secondary"></a> [asg\_secondary](#input\_asg\_secondary) | n/a | `any` | n/a | yes |
-| <a name="input_cfssl_version"></a> [cfssl\_version](#input\_cfssl\_version) | n/a | `string` | `"1.6.1"` | no |
+| <a name="input_cfssl_version"></a> [cfssl\_version](#input\_cfssl\_version) | n/a | `string` | `"1.6.2"` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | A name to prefix every created resource with | `string` | n/a | yes |
 | <a name="input_nlb_defaults"></a> [nlb\_defaults](#input\_nlb\_defaults) | n/a | `any` | <pre>{<br>  "internal": false,<br>  "ip_address_type": "dualstack",<br>  "listener_port": 443,<br>  "subnets": []<br>}</pre> | no |
 | <a name="input_nlbs"></a> [nlbs](#input\_nlbs) | n/a | `any` | <pre>{<br>  "external": {},<br>  "internal": {<br>    "internal": true<br>  }<br>}</pre> | no |
@@ -159,7 +159,7 @@ Instances have SSM enable by default, no need for SSH keys.
 | <a name="input_vault_pki_client_certs"></a> [vault\_pki\_client\_certs](#input\_vault\_pki\_client\_certs) | n/a | `any` | <pre>{<br>  "default": {<br>    "subject": {<br>      "common_name": "default-vault-client"<br>    },<br>    "usages": [<br>      "client_auth",<br>      "key_encipherement",<br>      "digital_signature"<br>    ]<br>  }<br>}</pre> | no |
 | <a name="input_vault_routing_policy"></a> [vault\_routing\_policy](#input\_vault\_routing\_policy) | n/a | `string` | `"all"` | no |
 | <a name="input_vault_tls_require_and_verify_client_cert"></a> [vault\_tls\_require\_and\_verify\_client\_cert](#input\_vault\_tls\_require\_and\_verify\_client\_cert) | n/a | `bool` | `false` | no |
-| <a name="input_vault_version"></a> [vault\_version](#input\_vault\_version) | n/a | `string` | `"1.11.1"` | no |
+| <a name="input_vault_version"></a> [vault\_version](#input\_vault\_version) | n/a | `string` | `"1.11.3"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC to use | `string` | n/a | yes |
 | <a name="input_vpc_peering_enabled"></a> [vpc\_peering\_enabled](#input\_vpc\_peering\_enabled) | n/a | `bool` | `true` | no |
 | <a name="input_vpc_secondary_id"></a> [vpc\_secondary\_id](#input\_vpc\_secondary\_id) | The ID of the VPC to use | `string` | n/a | yes |
@@ -172,5 +172,6 @@ Instances have SSM enable by default, no need for SSH keys.
 | <a name="output_primary"></a> [primary](#output\_primary) | n/a |
 | <a name="output_secondary"></a> [secondary](#output\_secondary) | n/a |
 | <a name="output_secrets"></a> [secrets](#output\_secrets) | n/a |
+| <a name="output_vault_dns_domain"></a> [vault\_dns\_domain](#output\_vault\_dns\_domain) | n/a |
 | <a name="output_vault_pki"></a> [vault\_pki](#output\_vault\_pki) | n/a |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -311,3 +311,24 @@ module "vault" {
     }
   }
 }
+
+output "vpc_primary" {
+  value = module.vpc_primary
+}
+
+output "vpc_endpoints_primary" {
+  value = module.vpc_primary
+}
+
+output "vpc_secondary" {
+  value = module.vpc_primary
+}
+
+output "vpc_endpoints_secondary" {
+  value = module.vpc_primary
+}
+
+output "vault" {
+  value     = module.vault
+  sensitive = true
+}

--- a/examples/minimal/main.tf
+++ b/examples/minimal/main.tf
@@ -171,7 +171,7 @@ module "vault" {
   vault_dns_domain                         = "vault-demo.particule.tech"
   vault_api_address                        = "https://vault-demo.particule.tech"
   vault_routing_policy                     = "all"
-  vault_tls_require_and_verify_client_cert = true
+  vault_tls_require_and_verify_client_cert = false
 
   route53_zone_name         = "particule.tech"
   route53_private_zone_name = ""
@@ -179,6 +179,7 @@ module "vault" {
   vpc_id              = module.vpc_primary.vpc_id
   vpc_secondary_id    = module.vpc_secondary.vpc_id
   vpc_peering_enabled = true
+
 
   asg = {
     vpc_zone_identifier = module.vpc_primary.private_subnets
@@ -208,4 +209,25 @@ module "vault" {
       internal = true
     }
   }
+}
+
+output "vpc_primary" {
+  value = module.vpc_primary
+}
+
+output "vpc_endpoints_primary" {
+  value = module.vpc_primary
+}
+
+output "vpc_secondary" {
+  value = module.vpc_primary
+}
+
+output "vpc_endpoints_secondary" {
+  value = module.vpc_primary
+}
+
+output "vault" {
+  value     = module.vault
+  sensitive = true
 }

--- a/modules/vault-region/asg.tf
+++ b/modules/vault-region/asg.tf
@@ -37,6 +37,12 @@ module "asg" {
   ebs_optimized     = try(var.asg.ebs_optimized, true)
   enable_monitoring = try(var.asg.enable_monitoring, true)
 
+  metadata_options = {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
   network_interfaces = [
     {
       security_groups             = [module.sg.security_group_id]

--- a/modules/vault-region/data.tf
+++ b/modules/vault-region/data.tf
@@ -4,7 +4,7 @@ data "aws_caller_identity" "current" {}
 
 data "aws_ami" "vault" {
   most_recent = true
-  name_regex  = "vault-${var.vault_version}-*"
+  name_regex  = "vault-${var.vault_version}-al2022-*"
   owners      = ["886701765425"]
 
   filter {

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,3 +21,7 @@ output "primary" {
 output "secondary" {
   value = module.primary
 }
+
+output "vault_dns_domain" {
+  value = var.vault_dns_domain
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,7 +17,7 @@ variable "tags" {
 }
 
 variable "cfssl_version" {
-  default = "1.6.1"
+  default = "1.6.2"
 }
 
 variable "vpc_peering_enabled" {
@@ -83,7 +83,7 @@ variable "vault_pki_client_certs" {
 }
 
 variable "vault_version" {
-  default = "1.11.1"
+  default = "1.11.3"
 }
 
 variable "vault_cert_dir" {


### PR DESCRIPTION
BREAKING CHANGE: use Amazon Linux 2022
* bump vault to v1.11.3
* bump cfssl to v1.6.3
* allow only IMDSv2

Signed-off-by: Kevin Lefevre <kevin@particule.io>
