### PR TITLE
feat: rework health checks

### DIFF
--- a/modules/vault-region/data.tf
+++ b/modules/vault-region/data.tf
@@ -2,6 +2,10 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
+data "aws_vpc" "vpc" {
+  id = var.vpc_id
+}
+
 data "aws_ami" "vault" {
   most_recent = true
   name_regex  = "vault-${var.vault_version}-al2022-*"

--- a/modules/vault-region/nlb.tf
+++ b/modules/vault-region/nlb.tf
@@ -38,40 +38,32 @@ resource "aws_lb_target_group" "vault" {
   deregistration_delay   = 0
 
   dynamic "health_check" {
-    for_each = var.vault_routing_policy == "leader_only" && !var.vault_tls_require_and_verify_client_cert ? [1] : []
+    for_each = var.vault_routing_policy == "leader_only" ? [1] : []
     content {
       enabled             = true
-      interval            = 10
+      interval            = 5
       path                = "/v1/sys/health"
-      protocol            = "HTTPS"
-      port                = "traffic-port"
+      protocol            = "HTTP"
+      port                = 9200
       healthy_threshold   = 2
       unhealthy_threshold = 2
+      timeout             = 2
+      matcher             = "200"
     }
   }
 
   dynamic "health_check" {
-    for_each = var.vault_routing_policy == "all" && !var.vault_tls_require_and_verify_client_cert ? [1] : []
+    for_each = var.vault_routing_policy == "all" ? [1] : []
     content {
       enabled             = true
-      interval            = 10
-      path                = "/v1/sys/leader"
-      protocol            = "HTTPS"
-      port                = "traffic-port"
+      interval            = 5
+      path                = "/v1/sys/health"
+      protocol            = "HTTP"
+      port                = 9200
       healthy_threshold   = 2
       unhealthy_threshold = 2
-    }
-  }
-
-  dynamic "health_check" {
-    for_each = var.vault_tls_require_and_verify_client_cert ? [1] : []
-    content {
-      enabled             = true
-      interval            = 10
-      protocol            = "TCP"
-      port                = "traffic-port"
-      healthy_threshold   = 2
-      unhealthy_threshold = 2
+      timeout             = 2
+      matcher             = "200,429"
     }
   }
 }

--- a/modules/vault-region/sgs.tf
+++ b/modules/vault-region/sgs.tf
@@ -21,6 +21,13 @@ module "sg" {
       protocol    = "tcp"
       cidr_blocks = "0.0.0.0/0"
     },
+    {
+      description = "NLB Health Checks"
+      from_port   = 9200
+      to_port     = 9200
+      protocol    = "tcp"
+      cidr_blocks = data.aws_vpc.vpc.cidr_block
+    },
   ]
   ingress_with_ipv6_cidr_blocks = [
     {
@@ -29,6 +36,13 @@ module "sg" {
       to_port          = 8200
       protocol         = "tcp"
       ipv6_cidr_blocks = "::/0"
+    },
+    {
+      description      = "NLB Health Checks"
+      from_port        = 9200
+      to_port          = 9200
+      protocol         = "tcp"
+      ipv6_cidr_blocks = data.aws_vpc.vpc.ipv6_cidr_block
     },
   ]
   egress_with_cidr_blocks = [

--- a/modules/vault-region/templates/userdata.sh
+++ b/modules/vault-region/templates/userdata.sh
@@ -42,7 +42,7 @@ seal "awskms" {
 }
 
 listener "tcp" {
-  address     = "127.0.0.1:9200"
+  address     = "0.0.0.0:9200"
   tls_disable = "true"
 }
 


### PR DESCRIPTION
BREAKING_CHANGE:
* Health check are now using HTTP by default
* Port 9200 listen without TLS inside the VPC
* Port 9200 allow traffic from inside the VPC only for health checks

Signed-off-by: Kevin Lefevre <kevin@particule.io>
