### PR TITLE
fix: AWS v6 provider compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Pariticule build and maintain AMI on AWS region available by default. Please pen
 Instances have SSM enable by default, no need for SSH keys.
 
 
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
@@ -142,17 +142,17 @@ Instances have SSM enable by default, no need for SSH keys.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_ami_name_regex"></a> [ami\_name\_regex](#input\_ami\_name\_regex) | n/a | `string` | `null` | no |
-| <a name="input_ami_owners"></a> [ami\_owners](#input\_ami\_owners) | n/a | `list(string)` | <pre>[<br>  "886701765425"<br>]</pre> | no |
+| <a name="input_ami_owners"></a> [ami\_owners](#input\_ami\_owners) | n/a | `list(string)` | <pre>[<br/>  "886701765425"<br/>]</pre> | no |
 | <a name="input_asg"></a> [asg](#input\_asg) | n/a | `any` | n/a | yes |
-| <a name="input_asg_defaults"></a> [asg\_defaults](#input\_asg\_defaults) | n/a | `any` | <pre>{<br>  "asg_associate_public_ip_address": false,<br>  "desired_capacity": 3,<br>  "disk_size": 20,<br>  "instance_type": "t3a.micro",<br>  "key_name": null,<br>  "max_size": 3,<br>  "min_size": 0,<br>  "tags": {},<br>  "tags_as_map": {},<br>  "vpc_zone_identifier": []<br>}</pre> | no |
+| <a name="input_asg_defaults"></a> [asg\_defaults](#input\_asg\_defaults) | n/a | `any` | <pre>{<br/>  "asg_associate_public_ip_address": false,<br/>  "desired_capacity": 3,<br/>  "disk_size": 20,<br/>  "instance_type": "t3a.micro",<br/>  "key_name": null,<br/>  "max_size": 3,<br/>  "min_size": 0,<br/>  "tags": {},<br/>  "tags_as_map": {},<br/>  "vpc_zone_identifier": []<br/>}</pre> | no |
 | <a name="input_asg_secondary"></a> [asg\_secondary](#input\_asg\_secondary) | n/a | `any` | n/a | yes |
 | <a name="input_cfssl_version"></a> [cfssl\_version](#input\_cfssl\_version) | n/a | `string` | `"1.6.4"` | no |
-| <a name="input_existing_dynamodb_tables"></a> [existing\_dynamodb\_tables](#input\_existing\_dynamodb\_tables) | use exising dynamodbs tables (useful for recovery) | <pre>object({<br>    primary = optional(object({<br>      name = string<br>    }))<br>    secondary = optional(object({<br>      name = string<br>    }))<br>  })</pre> | `{}` | no |
+| <a name="input_existing_dynamodb_tables"></a> [existing\_dynamodb\_tables](#input\_existing\_dynamodb\_tables) | use exising dynamodbs tables (useful for recovery) | <pre>object({<br/>    primary = optional(object({<br/>      name = string<br/>    }))<br/>    secondary = optional(object({<br/>      name = string<br/>    }))<br/>  })</pre> | `{}` | no |
 | <a name="input_existing_kms_seal_key_id"></a> [existing\_kms\_seal\_key\_id](#input\_existing\_kms\_seal\_key\_id) | use existing kms unseal key (useful for recovery) | `string` | `""` | no |
 | <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | A name to prefix every created resource with | `string` | n/a | yes |
-| <a name="input_nlb_defaults"></a> [nlb\_defaults](#input\_nlb\_defaults) | n/a | `any` | <pre>{<br>  "internal": false,<br>  "ip_address_type": "dualstack",<br>  "listener_port": 443,<br>  "subnets": []<br>}</pre> | no |
-| <a name="input_nlbs"></a> [nlbs](#input\_nlbs) | n/a | `any` | <pre>{<br>  "external": {},<br>  "internal": {<br>    "internal": true<br>  }<br>}</pre> | no |
-| <a name="input_nlbs_secondary"></a> [nlbs\_secondary](#input\_nlbs\_secondary) | n/a | `any` | <pre>{<br>  "external": {},<br>  "internal": {<br>    "internal": true<br>  }<br>}</pre> | no |
+| <a name="input_nlb_defaults"></a> [nlb\_defaults](#input\_nlb\_defaults) | n/a | `any` | <pre>{<br/>  "internal": false,<br/>  "ip_address_type": "dualstack",<br/>  "listener_port": 443,<br/>  "subnets": []<br/>}</pre> | no |
+| <a name="input_nlbs"></a> [nlbs](#input\_nlbs) | n/a | `any` | <pre>{<br/>  "external": {},<br/>  "internal": {<br/>    "internal": true<br/>  }<br/>}</pre> | no |
+| <a name="input_nlbs_secondary"></a> [nlbs\_secondary](#input\_nlbs\_secondary) | n/a | `any` | <pre>{<br/>  "external": {},<br/>  "internal": {<br/>    "internal": true<br/>  }<br/>}</pre> | no |
 | <a name="input_route53_private_zone_name"></a> [route53\_private\_zone\_name](#input\_route53\_private\_zone\_name) | n/a | `string` | `""` | no |
 | <a name="input_route53_zone_name"></a> [route53\_zone\_name](#input\_route53\_zone\_name) | n/a | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to apply to all resources | `map(string)` | `{}` | no |
@@ -165,7 +165,7 @@ Instances have SSM enable by default, no need for SSH keys.
 | <a name="input_vault_dns_domain"></a> [vault\_dns\_domain](#input\_vault\_dns\_domain) | The DNS address that vault will be accessible at | `string` | n/a | yes |
 | <a name="input_vault_max_lease_ttl"></a> [vault\_max\_lease\_ttl](#input\_vault\_max\_lease\_ttl) | n/a | `string` | `"192h"` | no |
 | <a name="input_vault_pki_ca_config"></a> [vault\_pki\_ca\_config](#input\_vault\_pki\_ca\_config) | n/a | `any` | `{}` | no |
-| <a name="input_vault_pki_client_certs"></a> [vault\_pki\_client\_certs](#input\_vault\_pki\_client\_certs) | n/a | `any` | <pre>{<br>  "default": {<br>    "subject": {<br>      "common_name": "default-vault-client"<br>    },<br>    "usages": [<br>      "client_auth",<br>      "key_encipherement",<br>      "digital_signature"<br>    ]<br>  }<br>}</pre> | no |
+| <a name="input_vault_pki_client_certs"></a> [vault\_pki\_client\_certs](#input\_vault\_pki\_client\_certs) | n/a | `any` | <pre>{<br/>  "default": {<br/>    "subject": {<br/>      "common_name": "default-vault-client"<br/>    },<br/>    "usages": [<br/>      "client_auth",<br/>      "key_encipherement",<br/>      "digital_signature"<br/>    ]<br/>  }<br/>}</pre> | no |
 | <a name="input_vault_prometheus_retention_time"></a> [vault\_prometheus\_retention\_time](#input\_vault\_prometheus\_retention\_time) | n/a | `string` | `"6h"` | no |
 | <a name="input_vault_routing_policy"></a> [vault\_routing\_policy](#input\_vault\_routing\_policy) | n/a | `string` | `"all"` | no |
 | <a name="input_vault_tls_min_version"></a> [vault\_tls\_min\_version](#input\_vault\_tls\_min\_version) | n/a | `string` | `"tls12"` | no |
@@ -185,4 +185,4 @@ Instances have SSM enable by default, no need for SSH keys.
 | <a name="output_secrets"></a> [secrets](#output\_secrets) | n/a |
 | <a name="output_vault_dns_domain"></a> [vault\_dns\_domain](#output\_vault\_dns\_domain) | n/a |
 | <a name="output_vault_pki"></a> [vault\_pki](#output\_vault\_pki) | n/a |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END_TF_DOCS -->

--- a/data.tf
+++ b/data.tf
@@ -31,12 +31,12 @@ data "aws_route_tables" "vpc_secondary" {
 }
 
 data "aws_dynamodb_table" "existing_dynamodb_table_primary" {
-  count = var.existing_dynamodb_tables == {} ? 0 : 1
+  count = can(var.existing_dynamodb_tables.primary.name) ? 1 : 0
   name  = var.existing_dynamodb_tables.primary.name
 }
 
 data "aws_dynamodb_table" "existing_dynamodb_table_secondary" {
-  count = var.existing_dynamodb_tables == {} ? 0 : 1
+  count = can(var.existing_dynamodb_tables.secondary.name) ? 1 : 0
   name  = var.existing_dynamodb_tables.secondary.name
 }
 

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -1,5 +1,5 @@
 resource "aws_dynamodb_table" "dynamodb_table" {
-  count = var.existing_dynamodb_tables == {} ? 1 : 0
+  count = can(var.existing_dynamodb_tables.primary.name) ? 0 : 1
   name  = var.name_prefix
 
   billing_mode     = "PAY_PER_REQUEST"

--- a/dynamodb.tf
+++ b/dynamodb.tf
@@ -28,7 +28,7 @@ resource "aws_dynamodb_table" "dynamodb_table" {
   }
 
   replica {
-    region_name            = data.aws_region.secondary.name
+    region_name            = data.aws_region.secondary.region
     point_in_time_recovery = true
     propagate_tags         = true
   }

--- a/ec2.tf
+++ b/ec2.tf
@@ -9,7 +9,7 @@ module "primary" {
 
   nlbs = local.nlbs
 
-  dynamodb_table_name = var.existing_dynamodb_tables == {} ? aws_dynamodb_table.dynamodb_table[0].id : var.existing_dynamodb_tables.primary.name
+  dynamodb_table_name = can(var.existing_dynamodb_tables.primary.name) ? var.existing_dynamodb_tables.primary.name : aws_dynamodb_table.dynamodb_table[0].id
 
   iam_instance_profile_arn = aws_iam_instance_profile.vault.arn
 
@@ -50,7 +50,7 @@ module "secondary" {
 
   nlbs = local.nlbs_secondary
 
-  dynamodb_table_name = var.existing_dynamodb_tables == {} ? aws_dynamodb_table.dynamodb_table[0].id : var.existing_dynamodb_tables.secondary.name
+  dynamodb_table_name = can(var.existing_dynamodb_tables.secondary.name) ? var.existing_dynamodb_tables.secondary.name : aws_dynamodb_table.dynamodb_table[0].id
 
   iam_instance_profile_arn = aws_iam_instance_profile.vault.arn
 

--- a/iam.tf
+++ b/iam.tf
@@ -77,10 +77,10 @@ data "aws_iam_policy_document" "vault" {
     ]
 
     resources = var.existing_dynamodb_tables == {} ? [
-      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.dynamodb_table[0].id}",
-      "arn:aws:dynamodb:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.dynamodb_table[0].id}/*",
-      "arn:aws:dynamodb:${data.aws_region.secondary.name}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.dynamodb_table[0].id}",
-      "arn:aws:dynamodb:${data.aws_region.secondary.name}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.dynamodb_table[0].id}/*",
+      "arn:aws:dynamodb:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.dynamodb_table[0].id}",
+      "arn:aws:dynamodb:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.dynamodb_table[0].id}/*",
+      "arn:aws:dynamodb:${data.aws_region.secondary.region}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.dynamodb_table[0].id}",
+      "arn:aws:dynamodb:${data.aws_region.secondary.region}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.dynamodb_table[0].id}/*",
       ] : [
       "${data.aws_dynamodb_table.existing_dynamodb_table_primary[0].arn}",
       "${data.aws_dynamodb_table.existing_dynamodb_table_primary[0].arn}/*",
@@ -115,8 +115,8 @@ data "aws_iam_policy_document" "vault" {
     ]
 
     resources = concat(
-      [for k, v in module.secrets.secrets : "arn:aws:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:${lookup(v, "name", k)}*"],
-      [for k, v in module.secrets.secrets : "arn:aws:secretsmanager:${data.aws_region.secondary.name}:${data.aws_caller_identity.current.account_id}:secret:${lookup(v, "name", k)}*"]
+      [for k, v in module.secrets.secrets : "arn:aws:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:${lookup(v, "name", k)}*"],
+      [for k, v in module.secrets.secrets : "arn:aws:secretsmanager:${data.aws_region.secondary.region}:${data.aws_caller_identity.current.account_id}:secret:${lookup(v, "name", k)}*"]
     )
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -76,7 +76,7 @@ data "aws_iam_policy_document" "vault" {
       "dynamodb:DescribeTable",
     ]
 
-    resources = var.existing_dynamodb_tables == {} ? [
+    resources = !can(data.aws_dynamodb_table.existing_dynamodb_table_primary[0]) || !can(data.aws_dynamodb_table.existing_dynamodb_table_secondary[0]) ? [
       "arn:aws:dynamodb:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.dynamodb_table[0].id}",
       "arn:aws:dynamodb:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.dynamodb_table[0].id}/*",
       "arn:aws:dynamodb:${data.aws_region.secondary.region}:${data.aws_caller_identity.current.account_id}:table/${aws_dynamodb_table.dynamodb_table[0].id}",

--- a/modules/vault-region/asg.tf
+++ b/modules/vault-region/asg.tf
@@ -11,7 +11,12 @@ module "asg" {
   desired_capacity    = try(var.asg.desired_capacity, 3)
   vpc_zone_identifier = var.asg.vpc_zone_identifier
 
-  target_group_arns = [for k, v in var.nlbs : aws_lb_target_group.vault[k].arn]
+  traffic_source_attachments = {
+    for k, v in var.nlbs: k => {
+      traffic_source_identifier = aws_lb_target_group.vault[k].arn
+      traffic_source_type = "elbv2"
+    }
+  }
 
   health_check_grace_period = try(var.asg.health_check_grace_period, 0)
   wait_for_capacity_timeout = try(var.asg.wait_for_capacity_timeout, 0)

--- a/modules/vault-region/asg.tf
+++ b/modules/vault-region/asg.tf
@@ -12,9 +12,9 @@ module "asg" {
   vpc_zone_identifier = var.asg.vpc_zone_identifier
 
   traffic_source_attachments = {
-    for k, v in var.nlbs: k => {
+    for k, v in var.nlbs : k => {
       traffic_source_identifier = aws_lb_target_group.vault[k].arn
-      traffic_source_type = "elbv2"
+      traffic_source_type       = "elbv2"
     }
   }
 

--- a/modules/vault-region/data.tf
+++ b/modules/vault-region/data.tf
@@ -35,7 +35,7 @@ data "cloudinit_config" "userdata" {
       {
         account_id                               = data.aws_caller_identity.current.account_id
         name_prefix                              = var.name_prefix
-        region                                   = data.aws_region.current.name
+        region                                   = data.aws_region.current.region
         vault_cert_dir                           = var.vault_cert_dir
         vault_config_dir                         = var.vault_config_dir
         vault_additional_userdata                = var.vault_additional_userdata

--- a/outputs.tf
+++ b/outputs.tf
@@ -3,7 +3,7 @@ output "secrets" {
 }
 
 output "dynamodb" {
-  value = aws_dynamodb_table.dynamodb_table
+  value = try(aws_dynamodb_table.dynamodb_table[0], null)
 }
 
 output "vault_pki" {

--- a/peering.tf
+++ b/peering.tf
@@ -2,7 +2,7 @@ resource "aws_vpc_peering_connection" "vault" {
   count       = var.vpc_peering_enabled ? 1 : 0
   vpc_id      = var.vpc_id
   peer_vpc_id = var.vpc_secondary_id
-  peer_region = data.aws_region.secondary.name
+  peer_region = data.aws_region.secondary.region
   auto_accept = false
 
   tags = merge(

--- a/route53.tf
+++ b/route53.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "public_a" {
     weight = 1
   }
 
-  set_identifier = "${var.name_prefix}-${data.aws_region.current.name}"
+  set_identifier = "${var.name_prefix}-${data.aws_region.current.region}"
 
   alias {
     name                   = module.primary.nlbs.external.dns_name
@@ -32,7 +32,7 @@ resource "aws_route53_record" "public_a_secondary" {
     weight = 1
   }
 
-  set_identifier = "${var.name_prefix}-${data.aws_region.secondary.name}"
+  set_identifier = "${var.name_prefix}-${data.aws_region.secondary.region}"
 
   alias {
     name                   = module.secondary.nlbs.external.dns_name
@@ -51,7 +51,7 @@ resource "aws_route53_record" "public_aaaa" {
     weight = 1
   }
 
-  set_identifier = "${var.name_prefix}-${data.aws_region.current.name}"
+  set_identifier = "${var.name_prefix}-${data.aws_region.current.region}"
 
   alias {
     name                   = module.primary.nlbs.external.dns_name
@@ -70,7 +70,7 @@ resource "aws_route53_record" "public_aaaa_secondary" {
     weight = 1
   }
 
-  set_identifier = "${var.name_prefix}-${data.aws_region.secondary.name}"
+  set_identifier = "${var.name_prefix}-${data.aws_region.secondary.region}"
 
   alias {
     name                   = module.secondary.nlbs.external.dns_name

--- a/route53_private.tf
+++ b/route53_private.tf
@@ -14,7 +14,7 @@ resource "aws_route53_record" "private_a" {
     weight = 1
   }
 
-  set_identifier = "${var.name_prefix}-${data.aws_region.current.name}"
+  set_identifier = "${var.name_prefix}-${data.aws_region.current.region}"
 
   alias {
     name                   = module.primary.nlbs.internal.dns_name
@@ -33,7 +33,7 @@ resource "aws_route53_record" "private_a_secondary" {
     weight = 1
   }
 
-  set_identifier = "${var.name_prefix}-${data.aws_region.secondary.name}"
+  set_identifier = "${var.name_prefix}-${data.aws_region.secondary.region}"
 
   alias {
     name                   = module.secondary.nlbs.internal.dns_name
@@ -52,7 +52,7 @@ resource "aws_route53_record" "private_aaaa" {
     weight = 1
   }
 
-  set_identifier = "${var.name_prefix}-${data.aws_region.current.name}"
+  set_identifier = "${var.name_prefix}-${data.aws_region.current.region}"
 
   alias {
     name                   = module.primary.nlbs.internal.dns_name
@@ -71,7 +71,7 @@ resource "aws_route53_record" "private_aaaa_secondary" {
     weight = 1
   }
 
-  set_identifier = "${var.name_prefix}-${data.aws_region.secondary.name}"
+  set_identifier = "${var.name_prefix}-${data.aws_region.secondary.region}"
 
   alias {
     name                   = module.secondary.nlbs.internal.dns_name

--- a/secrets.tf
+++ b/secrets.tf
@@ -9,7 +9,7 @@ module "secrets" {
       content = module.pki.ca.cert.cert_pem
       replicas = [
         {
-          region = data.aws_region.secondary.name
+          region = data.aws_region.secondary.region
         }
       ]
       force_overwrite_replica_secret = true
@@ -20,7 +20,7 @@ module "secrets" {
       content = module.pki.ca.private_key.private_key_pem
       replicas = [
         {
-          region = data.aws_region.secondary.name
+          region = data.aws_region.secondary.region
         }
       ]
       force_overwrite_replica_secret = true


### PR DESCRIPTION
This PR addresses various deprecations and bumps the AWS autoscaling module to v9 so that it is compatible with the AWS terraform provider v6